### PR TITLE
Version 2.5.0 - Add base Factorio compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,19 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.5.0
+Date: 2026-01-31
+  Major Features:
+    - Base Factorio compatibility - mod now works without Space Age expansion!
+  Changes:
+    - Made Space Age an optional dependency
+    - Space Age science conversions (tiers 5-9) only load when expansion is installed
+    - Base game conversions (tiers 1-4) always available
+    - Updated mod description to reflect dual compatibility
+  Info:
+    - Base Factorio: 4 technologies unlocking 8 recipes (Red↔Green, Green↔Blue, Blue↔Purple, Purple↔Yellow)
+    - With Space Age: All 9 technologies unlocking 18 recipes (includes planet sciences)
+    - No configuration needed - automatically detects installed content
+    - All existing settings work with both versions
+---------------------------------------------------------------------------------------------------
 Version: 2.4.0
 Date: 2026-01-25
   Major Features:

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -30,7 +30,8 @@ local tier_enabled = {
 -- Tier 4: Purple (production), Tier 5: Yellow (utility), Tier 6: White (space)
 -- Tier 7: Orange/Pink/Lime/Dark-blue (planet sciences), Tier 8: Black (promethium)
 
-local conversion_data = {
+-- Base game conversion data (always available)
+local base_conversion_data = {
     -- Format: {recipe_name, tier_difference, is_upgrade, tier_number, technology_name}
     -- Tier 1: Red <-> Green
     {"red-to-green", 1, true, 1, "science-conversion-one"},
@@ -46,8 +47,11 @@ local conversion_data = {
     
     -- Tier 4: Purple <-> Yellow
     {"purple-to-yellow", 1, true, 4, "science-conversion-four"},
-    {"yellow-to-purple", 1, false, 4, "science-conversion-four"},
-    
+    {"yellow-to-purple", 1, false, 4, "science-conversion-four"}
+}
+
+-- Space Age conversion data (only if Space Age is installed)
+local space_age_conversion_data = {
     -- Tier 5: White <-> Orange
     {"white-to-orange", 1, true, 5, "science-conversion-five"},
     {"orange-to-white", 1, false, 5, "science-conversion-five"},
@@ -68,6 +72,18 @@ local conversion_data = {
     {"white-to-black", 2, true, 9, "science-conversion-nine"},
     {"black-to-white", 2, false, 9, "science-conversion-nine"}
 }
+
+-- Combine conversion data based on available mods
+local conversion_data = {}
+for _, v in pairs(base_conversion_data) do
+    table.insert(conversion_data, v)
+end
+
+if mods["space-age"] then
+    for _, v in pairs(space_age_conversion_data) do
+        table.insert(conversion_data, v)
+    end
+end
 
 -- Function to calculate ingredient amount based on settings
 local function calculate_ingredient_amount(tier_diff, is_upgrade)
@@ -157,12 +173,16 @@ end
 
 -- Special handling for linear scaling with more granular tier differences
 if linear_scaling then
-    -- Adjust specific recipes to match original progression
-    local special_scaling = {
+    -- Base game special scaling
+    local base_special_scaling = {
         ["red-to-green"] = {scale = 1, tier = 1},    -- 10 * 1 = 10
         ["green-to-blue"] = {scale = 2, tier = 2},   -- 10 * 2 = 20
         ["blue-to-purple"] = {scale = 3, tier = 3},  -- 10 * 3 = 30
-        ["purple-to-yellow"] = {scale = 5, tier = 4}, -- 10 * 5 = 50
+        ["purple-to-yellow"] = {scale = 5, tier = 4} -- 10 * 5 = 50
+    }
+    
+    -- Space Age special scaling (only if Space Age is installed)
+    local space_age_special_scaling = {
         ["white-to-orange"] = {scale = 10, tier = 5}, -- 10 * 10 = 100
         ["white-to-pink"] = {scale = 10, tier = 6},
         ["white-to-lime"] = {scale = 10, tier = 7},
@@ -170,6 +190,19 @@ if linear_scaling then
         ["white-to-black"] = {scale = 10, tier = 9}
     }
     
+    -- Combine special scaling based on available mods
+    local special_scaling = {}
+    for k, v in pairs(base_special_scaling) do
+        special_scaling[k] = v
+    end
+    
+    if mods["space-age"] then
+        for k, v in pairs(space_age_special_scaling) do
+            special_scaling[k] = v
+        end
+    end
+    
+    -- Apply special scaling
     for recipe_name, scaling_data in pairs(special_scaling) do
         -- Only apply if tier is enabled
         if tier_enabled[scaling_data.tier] then

--- a/info.json
+++ b/info.json
@@ -1,10 +1,10 @@
 {"name": "ScienceConversion",
-"version": "2.4.0",
+"version": "2.5.0",
 "title": "Science Conversion",
 "author": "narokuu",
 "contact": "Discord: Narokuu", 
 "homepage": "narokuu.blog",
 "factorio_version": "2.0",
-"dependencies": ["base >= 2.0"],
-"description":"This mod allows the ability to convert science packs into one another, Up and down a tier! Including space age sciences!"
+"dependencies": ["base >= 2.0", "? space-age"],
+"description":"This mod allows the ability to convert science packs into one another, Up and down a tier! Works with both base Factorio and Space Age expansion."
 }

--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -1,4 +1,5 @@
-data:extend({
+-- Base game recipes (always available)
+local base_recipes = {
     {
       type = "recipe",
       name = "green-to-red",
@@ -94,7 +95,11 @@ data:extend({
       results = {
         {type = "item", name = "production-science-pack", amount = 1}
       }
-    },
+    }
+}
+
+-- Space Age recipes (only if Space Age is installed)
+local space_age_recipes = {
     {
       type = "recipe",
       name = "white-to-orange",
@@ -215,4 +220,12 @@ data:extend({
         {type = "item", name = "space-science-pack", amount = 1}
       }
     }
-})
+}
+
+-- Load base game recipes
+data:extend(base_recipes)
+
+-- Load Space Age recipes only if the expansion is installed
+if mods["space-age"] then
+    data:extend(space_age_recipes)
+end

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -1,4 +1,5 @@
-data:extend({
+-- Base game technologies (always available)
+local base_technologies = {
     {
         type = "technology",
         name = "science-conversion-one",
@@ -78,7 +79,11 @@ data:extend({
             },
             time = 30
         }
-    },
+    }
+}
+
+-- Space Age technologies (only if Space Age is installed)
+local space_age_technologies = {
     {
         type = "technology",
         name = "science-conversion-five",
@@ -209,4 +214,12 @@ data:extend({
             time = 30
         }
     }
-})
+}
+
+-- Load base game technologies
+data:extend(base_technologies)
+
+-- Load Space Age technologies only if the expansion is installed
+if mods["space-age"] then
+    data:extend(space_age_technologies)
+end


### PR DESCRIPTION
Make Space Age an optional dependency so the mod works with both base
Factorio and the Space Age expansion.

Changes:
- Split recipes into base (tiers 1-4) and Space Age (tiers 5-9)
- Split technologies into base and Space Age sections
- Conditional loading based on mods["space-age"] detection
- Updated data-final-fixes.lua to handle both scenarios
- Bumped version to 2.5.0 in info.json
- Updated changelog with v2.5.0 entry

Base Factorio: 4 technologies, 8 recipes (Red↔Green through Purple↔Yellow)
Space Age: All 9 technologies, 18 recipes (includes planet sciences)

Fixes issue where users without Space Age expansion couldn't use the mod.
